### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -95,9 +95,23 @@
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
-
+			// SECURITY: 'target' must be a jQuery object, a DOM element, or a CSS selector string.
+			// If a string is provided, it will be interpreted as a CSS selector, NOT as HTML.
+			if (window.jQuery && config.target instanceof window.jQuery) {
+				// Already a jQuery object, use as-is.
+			} else if (typeof config.target === 'string') {
+				// If string starts with '<', treat as invalid to prevent XSS.
+				if (config.target.trim().startsWith('<')) {
+					throw new Error("panel: 'target' option must not be HTML. Use a CSS selector or jQuery object.");
+				}
+				// Use find to interpret as CSS selector.
+				config.target = $.find ? $($.find(config.target)) : $(config.target);
+			} else if (config.target && config.target.nodeType === 1) {
+				// DOM element
+				config.target = $(config.target);
+			} else {
+				throw new Error("panel: 'target' option must be a jQuery object, DOM element, or CSS selector string.");
+			}
 		// Panel.
 
 			// Methods.


### PR DESCRIPTION
Potential fix for [https://github.com/Aoliterature-Club/AoiFanCrowdfunding/security/code-scanning/1](https://github.com/Aoliterature-Club/AoiFanCrowdfunding/security/code-scanning/1)

To fix the problem, we should ensure that the `target` option in `userConfig` is always interpreted as a CSS selector or a jQuery object, and never as HTML. The best way is to:
- Document in the code that `target` must be a jQuery object or a CSS selector, and never raw HTML.
- If `target` is a string, use `jQuery.find()` to select an element by CSS selector, rather than passing it directly to `$()`, which could interpret it as HTML.
- If `target` is already a jQuery object, use it as-is.
- If `target` is a DOM element, wrap it with `$()` safely.
- Add a runtime check to ensure that if `target` is a string, it does not start with `<`, or use `find()` instead of `$()`.

The change should be made in the block around line 99 in `assets/js/util.js`, where `config.target` is expanded. Also, add a comment documenting the requirement for safe input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
